### PR TITLE
Add tests for `task`

### DIFF
--- a/labtech/tasks.py
+++ b/labtech/tasks.py
@@ -21,7 +21,7 @@ CACHE_DEFAULT = CacheDefault()
 
 _RESERVED_ATTRS = [
     '_lt', '_is_task', 'cache_key', 'result', '_results_map', '_set_results_map',
-    'result_meta', '_set_result_meta', 'context', 'set_context',
+    'result_meta', '_set_result_meta', 'context', 'set_context', '__post_init__',
 ]
 """Reserved attribute names for task types."""
 
@@ -197,7 +197,7 @@ def task(*args,
                 if hasattr(cls, reserved_attr):
                     raise AttributeError(f"Task type already defines reserved attribute '{reserved_attr}'.")
 
-        post_init = getattr(cls, '__post_init__', None)
+        post_init = getattr(cls, 'post_init', None)
         cls.__post_init__ = _task_post_init
 
         cls = dataclass(frozen=True, eq=True, order=True)(cls)

--- a/labtech/tasks.py
+++ b/labtech/tasks.py
@@ -19,6 +19,11 @@ class CacheDefault:
 
 CACHE_DEFAULT = CacheDefault()
 
+_RESERVED_ATTRS = [
+    '_lt', '_is_task', 'cache_key', 'result', '_results_map', '_set_results_map',
+    'result_meta', '_set_result_meta', 'context', 'set_context',
+]
+"""Reserved attribute names for task types."""
 
 def immutable_param_value(key: str, value: Any) -> Any:
     """Converts a parameter value to an immutable equivalent that is hashable."""
@@ -187,16 +192,12 @@ def task(*args,
     def decorator(cls):
         nonlocal cache
 
-        reserved_attrs = [
-            '_lt', '_is_task', 'cache_key', 'result', '_results_map', '_set_results_map',
-            'result_meta', '_set_result_meta', 'context', 'set_context',
-        ]
         if not is_task_type(cls):
-            for reserved_attr in reserved_attrs:
+            for reserved_attr in _RESERVED_ATTRS:
                 if hasattr(cls, reserved_attr):
                     raise AttributeError(f"Task type already defines reserved attribute '{reserved_attr}'.")
 
-        post_init = getattr(cls, 'post_init', None)
+        post_init = getattr(cls, '__post_init__', None)
         cls.__post_init__ = _task_post_init
 
         cls = dataclass(frozen=True, eq=True, order=True)(cls)

--- a/labtech/tasks.py
+++ b/labtech/tasks.py
@@ -25,6 +25,7 @@ _RESERVED_ATTRS = [
 ]
 """Reserved attribute names for task types."""
 
+
 def immutable_param_value(key: str, value: Any) -> Any:
     """Converts a parameter value to an immutable equivalent that is hashable."""
     if isinstance(value, list) or isinstance(value, tuple):

--- a/labtech/types.py
+++ b/labtech/types.py
@@ -86,12 +86,12 @@ TaskT = TypeVar("TaskT", bound=Task)
 def is_task_type(cls):
     """Returns `True` if the given `cls` is a class decorated with
     [`labtech.task`][labtech.task]."""
-    return isclass(cls) and hasattr(cls, '_lt')
+    return isclass(cls) and isinstance(getattr(cls, '_lt', None), TaskInfo)
 
 
 def is_task(obj):
     """Returns `True` if the given `obj` is an instance of a task class."""
-    return hasattr(obj, '_is_task')
+    return is_task_type(type(obj)) and hasattr(obj, '_is_task')
 
 
 class Storage(ABC):

--- a/tests/labtech/test_tasks.py
+++ b/tests/labtech/test_tasks.py
@@ -195,6 +195,19 @@ class TestTask:
                 def run(self) -> None:
                     pass
 
+    def test_inheritance(self) -> None:
+        @labtech.task
+        class SimpleTask:
+            def run(self) -> None:
+                pass
+
+        @labtech.task
+        class SubTask(SimpleTask):
+            def run(self) -> None:
+                pass
+
+        # Check we don't get an error trying to do this.
+        SubTask()
 
 class TestImmutableParamValue:
     def test_empty_list(self) -> None:

--- a/tests/labtech/test_tasks.py
+++ b/tests/labtech/test_tasks.py
@@ -1,7 +1,6 @@
-from dataclasses import FrozenInstanceError, dataclass
 import re
+from dataclasses import FrozenInstanceError
 from enum import Enum
-from typing import Literal
 
 import labtech.tasks
 import pytest
@@ -185,8 +184,11 @@ class TestTask:
                 run: int
 
     def test_post_init_missing_dunder(self) -> None:
-        match = re.escape("Task type already defines reserved attribute '__post_init__'.")
+        match = re.escape(
+            "Task type already defines reserved attribute '__post_init__'."
+        )
         with pytest.raises(AttributeError, match=match):
+
             @labtech.task
             class SimpleTask:
                 def __post_init__(self):
@@ -208,6 +210,7 @@ class TestTask:
 
         # Check we don't get an error trying to do this.
         SubTask()
+
 
 class TestImmutableParamValue:
     def test_empty_list(self) -> None:

--- a/tests/labtech/test_tasks.py
+++ b/tests/labtech/test_tasks.py
@@ -103,6 +103,9 @@ class TestTask:
                 def _lt(self) -> None:
                     pass
 
+                def _is_task(self) -> None:
+                    pass
+
     @pytest.mark.parametrize("badattr", _RESERVED_ATTRS)
     def test_fail_reserved_attrs(self, badattr: str) -> None:
         class SimpleTaskBase:

--- a/tests/labtech/test_tasks.py
+++ b/tests/labtech/test_tasks.py
@@ -121,7 +121,7 @@ class TestTask:
     def test_stored_post_init(self) -> None:
         @labtech.task
         class SimpleTask:
-            def __post_init__(self):
+            def post_init(self):
                 return "It's me!"
 
             def run(self) -> None:
@@ -182,19 +182,15 @@ class TestTask:
                 run: int
 
     def test_post_init_missing_dunder(self) -> None:
-        """This checks a bug is fixed where we were storing `post_init` instead of `__post_init__`."""
+        match = re.escape("Task type already defines reserved attribute '__post_init__'.")
+        with pytest.raises(AttributeError, match=match):
+            @labtech.task
+            class SimpleTask:
+                def __post_init__(self):
+                    pass
 
-        @labtech.task
-        class SimpleTask:
-            def post_init(self):
-                pass
-
-            def run(self) -> None:
-                pass
-
-        task = SimpleTask()
-        task_info: TaskInfo = task._lt
-        assert task_info.orig_post_init is None
+                def run(self) -> None:
+                    pass
 
 
 class TestImmutableParamValue:


### PR DESCRIPTION
Lots of unit tests.

Two are failing. `_lt` is a reserved keyword, but it is also being used as a way to detect classes which are tasks - and we don't raise errors about reserved attributes in such cases. Is this just for if we are inheriting from a previously defined Task class? I wonder whether there is a better way to do this (perhaps by inspecting directly the MRO), because I think we still want to protect the user if they accidentally use `_lt` as an attribute.

Keen to know what you'd do about this.