### PR TITLE
Add tests for `find_tasks_in_param`

### DIFF
--- a/labtech/tasks.py
+++ b/labtech/tasks.py
@@ -259,4 +259,4 @@ def find_tasks_in_param(param_value: Any, searched_coll_ids: Optional[Set[int]] 
 
     # This should be impossible.
     msg = f"Unexpected type {type(param_value).__qualname__} encountered in task parameter value."
-    raise AssertionError(msg)
+    raise TaskError(msg)

--- a/labtech/tasks.py
+++ b/labtech/tasks.py
@@ -13,7 +13,9 @@ from .cache import PickleCache, NullCache
 from .exceptions import TaskError
 from .utils import ensure_dict_key_str
 
+
 ParamScalar: TypeAlias = None | str | bool | float | int | Enum
+
 
 class CacheDefault:
     pass
@@ -21,13 +23,12 @@ class CacheDefault:
 
 CACHE_DEFAULT = CacheDefault()
 
+
 _RESERVED_ATTRS = [
     '_lt', '_is_task', 'cache_key', 'result', '_results_map', '_set_results_map',
     'result_meta', '_set_result_meta', 'context', 'set_context', '__post_init__',
 ]
 """Reserved attribute names for task types."""
-
-
 
 
 def immutable_param_value(key: str, value: Any) -> Any:

--- a/labtech/tasks.py
+++ b/labtech/tasks.py
@@ -245,7 +245,7 @@ def find_tasks_in_param(param_value: Any, searched_coll_ids: Optional[Set[int]] 
             for item in param_value
             for task in find_tasks_in_param(item, searched_coll_ids)
         ]
-    elif isinstance(param_value, dict):
+    elif isinstance(param_value, dict) or isinstance(param_value, frozendict):
         searched_coll_ids = searched_coll_ids | {id(param_value)}
         return [
             task

--- a/labtech/tasks.py
+++ b/labtech/tasks.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass, fields
 from enum import Enum
 from inspect import isclass
+from types import UnionType
 from typing import TypeAlias, cast, Any, Dict, Optional, Sequence, Set, Union
 
 from frozendict import frozendict
@@ -38,7 +39,7 @@ def immutable_param_value(key: str, value: Any) -> Any:
             ensure_dict_key_str(dict_key, exception_type=TaskError): immutable_param_value(f'{key}["{dict_key}"]', dict_value)
             for dict_key, dict_value in value.items()
         })
-    is_scalar = isinstance(value, ParamScalar)
+    is_scalar = isinstance(value, cast(UnionType, ParamScalar))
     if is_scalar or is_task(value):
         return value
     raise TaskError(f"Unsupported type '{type(value).__qualname__}' in parameter value '{key}'.")
@@ -253,7 +254,7 @@ def find_tasks_in_param(param_value: Any, searched_coll_ids: Optional[Set[int]] 
             for item in param_value.values()
             for task in find_tasks_in_param(item, searched_coll_ids)
         ]
-    elif isinstance(param_value, ParamScalar):
+    elif isinstance(param_value, cast(UnionType, ParamScalar)):
         return []
 
     # This should be impossible.

--- a/tests/labtech/test_tasks.py
+++ b/tests/labtech/test_tasks.py
@@ -286,7 +286,7 @@ class TestImmutableParamValue:
 
     def test_unhandled(self) -> None:
         with pytest.raises(
-            TaskError, match="Unsupported type 'BadObject' in parameter value 'hello'."
+            TaskError, match="Unsupported type '_BadObject' in parameter value 'hello'."
         ):
             immutable_param_value("hello", _BadObject())
 

--- a/tests/labtech/test_tasks.py
+++ b/tests/labtech/test_tasks.py
@@ -345,5 +345,5 @@ class TestFindTasksInParam:
         match = re.escape(
             "Unexpected type _BadObject encountered in task parameter value."
         )
-        with pytest.raises(AssertionError, match=match):
+        with pytest.raises(TaskError, match=match):
             find_tasks_in_param(_BadObject())

--- a/tests/labtech/test_tasks.py
+++ b/tests/labtech/test_tasks.py
@@ -8,9 +8,8 @@ import pytest
 from frozendict import frozendict
 from labtech.cache import BaseCache, NullCache, PickleCache
 from labtech.exceptions import TaskError
-from labtech.tasks import _RESERVED_ATTRS, immutable_param_value
+from labtech.tasks import _RESERVED_ATTRS, immutable_param_value, ParamScalar, find_tasks_in_param
 from labtech.types import ResultT, Storage, Task, TaskInfo
-from labtech.tasks import ParamScalar, find_tasks_in_param, immutable_param_value
 
 
 class _BadObject:
@@ -23,7 +22,7 @@ class _ExampleEnum(Enum):
     A = 1
     B = 2
 
-    
+
 @labtech.task
 class ExampleTask:
     a: int
@@ -46,7 +45,6 @@ class ExampleTask:
 )
 def scalar(request: pytest.FixtureRequest) -> ParamScalar:
     return request.param
-
 
 
 class BadCache(BaseCache):


### PR DESCRIPTION
Add unit tests.

Some refactoring to have a one-source-of-truth for information about what scalars are supported in labtech tasks parameters.