### PR TITLE
Add some integration tests to match README examples

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 160
-exclude = .git,__pycache__,docs/source/conf.py,old,build,dist,.venv,.eggs,*.egg-info
+exclude = .git,__pycache__,docs/source/conf.py,tests/integration/readme,old,build,dist,.venv,.eggs,*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ dist/
 
 # Virtual Environments
 .venv/
+
+# lab used during tests for README examples
+demo_lab/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ pip install labtech
 
 ## Usage
 
+<!-- N.B. keep this code in-sync with tests/integration/readme/usage.py -->
 ```python
 from time import sleep
 
@@ -104,6 +105,7 @@ Tasks parameters can be any of the following types:
 Here's an example of defining a single long-running task to produce a
 result for a large number of dependent tasks:
 
+<!-- N.B. keep this code in-sync with tests/integration/readme/dependents_and_mermaid.py -->
 ```python
 from time import sleep
 
@@ -146,6 +148,7 @@ if __name__ == '__main__':
 Labtech can even generate a [Mermaid diagram](https://mermaid.js.org/syntax/classDiagram.html)
 to visualise your tasks:
 
+<!-- N.B. keep this code in-sync with tests/integration/readme/dependents_and_mermaid.py -->
 ```python
 from labtech.diagram import display_task_diagram
 

--- a/tests/integration/readme/dependents_and_mermaid.py
+++ b/tests/integration/readme/dependents_and_mermaid.py
@@ -1,0 +1,49 @@
+from time import sleep
+
+import labtech
+
+@labtech.task
+class SlowTask:
+    base: int
+
+    def run(self) -> int:
+        # sleep(5)
+        return self.base ** 2
+
+@labtech.task
+class DependentTask:
+    slow_task: SlowTask
+    multiplier: int
+
+    def run(self) -> int:
+        return self.multiplier * self.slow_task.result
+
+def main():
+    some_slow_task = SlowTask(base=42)
+    dependent_tasks = [
+        DependentTask(
+            slow_task=some_slow_task,
+            multiplier=multiplier,
+        )
+        for multiplier in range(10)
+    ]
+
+    lab = labtech.Lab(storage='demo_lab')
+    results = lab.run_tasks(dependent_tasks)
+    print([results[task] for task in dependent_tasks])
+
+if __name__ == '__main__':
+    main()
+
+from labtech.diagram import display_task_diagram
+
+some_slow_task = SlowTask(base=42)
+dependent_tasks = [
+    DependentTask(
+        slow_task=some_slow_task,
+        multiplier=multiplier,
+    )
+    for multiplier in range(10)
+]
+
+display_task_diagram(dependent_tasks)

--- a/tests/integration/readme/usage.py
+++ b/tests/integration/readme/usage.py
@@ -1,0 +1,43 @@
+from time import sleep
+
+import labtech
+
+# Decorate your task class with @labtech.task:
+@labtech.task
+class Experiment:
+    # Each Experiment task instance will take `base` and `power` parameters:
+    base: int
+    power: int
+
+    def run(self) -> int:
+        # Define the task's run() method to return the result of the experiment:
+        labtech.logger.info(f'Raising {self.base} to the power of {self.power}')
+        # sleep(1)
+        return self.base ** self.power
+
+def main():
+    # Configure Experiment parameter permutations
+    experiments = [
+        Experiment(
+            base=base,
+            power=power,
+        )
+        for base in range(5)
+        for power in range(5)
+    ]
+
+    # Configure a Lab to run the experiments:
+    lab = labtech.Lab(
+        # Specify a directory to cache results in (running the experiments a second
+        # time will just load results from the cache!):
+        storage='demo_lab',
+        # Control the degree of parallelism:
+        max_workers=5,
+    )
+
+    # Run the experiments!
+    results = lab.run_tasks(experiments)
+    print([results[experiment] for experiment in experiments])
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/test_readme.py
+++ b/tests/integration/test_readme.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT_PROJ_DIR = Path(__file__).parents[3]
+README_PKG = Path(__file__).parent / "readme"
+
+class TestReadmeExamples:
+    def test_usage_subprocess(self) -> None:
+        cproc = _run_example_subprocess("usage")
+        assert cproc.stdout == b"[1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 4, 8, 16, 1, 3, 9, 27, 81, 1, 4, 16, 64, 256]\r\n"
+
+    def test_dependents_and_mermaid_subprocess(self) -> None:
+        cproc = _run_example_subprocess("dependents_and_mermaid")
+        stdout = b"<IPython.core.display.Markdown object>\r\n" * 11
+        stdout += b"[0, 1764, 3528, 5292, 7056, 8820, 10584, 12348, 14112, 15876]\r\n"
+
+        # Final mermaid display
+        stdout += b"<IPython.core.display.Markdown object>\r\n"
+        assert cproc.stdout == stdout
+
+
+def _run_example_subprocess(name: str) -> subprocess.CompletedProcess:
+    cproc = subprocess.run(
+        [
+            sys.executable,
+            (README_PKG / f"{name}.py").relative_to(ROOT_PROJ_DIR).as_posix(),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=ROOT_PROJ_DIR,
+        shell=True,
+    )
+    assert cproc.returncode == 0, cproc.stderr.decode() if cproc.stderr else None
+    return cproc

--- a/tests/integration/test_readme.py
+++ b/tests/integration/test_readme.py
@@ -13,11 +13,27 @@ class TestReadmeExamples:
 
     def test_dependents_and_mermaid_subprocess(self) -> None:
         cproc = _run_example_subprocess("dependents_and_mermaid")
-        mkdown_obj = "<IPython.core.display.Markdown object>\n"
         listout = "[0, 1764, 3528, 5292, 7056, 8820, 10584, 12348, 14112, 15876]\n"
+        diagram = (
+            'classDiagram\n'
+            '    direction BT\n'
+            '\n'
+            '    class DependentTask\n'
+            '    DependentTask : SlowTask slow_task\n'
+            '    DependentTask : int multiplier\n'
+            '    DependentTask : run() int\n'
+            '\n'
+            '    class SlowTask\n'
+            '    SlowTask : int base\n'
+            '    SlowTask : run() int\n'
+            '\n'
+            '\n'
+            '    DependentTask <-- SlowTask: slow_task\n'
+        )
+        
 
         stdout = cproc.stdout.decode().replace("\r", "")
-        assert stdout.endswith(listout + mkdown_obj)
+        assert stdout.endswith(listout + diagram)
 
 
 def _run_example_subprocess(name: str) -> subprocess.CompletedProcess:

--- a/tests/integration/test_readme.py
+++ b/tests/integration/test_readme.py
@@ -9,7 +9,7 @@ README_PKG = Path(__file__).parent / "readme"
 class TestReadmeExamples:
     def test_usage_subprocess(self) -> None:
         cproc = _run_example_subprocess("usage")
-        assert cproc.stdout.decode().replace("\r","") == "[1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 4, 8, 16, 1, 3, 9, 27, 81, 1, 4, 16, 64, 256]\n"
+        assert cproc.stdout.decode().replace("\r", "") == "[1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 4, 8, 16, 1, 3, 9, 27, 81, 1, 4, 16, 64, 256]\n"
 
     def test_dependents_and_mermaid_subprocess(self) -> None:
         cproc = _run_example_subprocess("dependents_and_mermaid")
@@ -18,7 +18,7 @@ class TestReadmeExamples:
 
         # Final mermaid display
         stdout += "<IPython.core.display.Markdown object>\n"
-        assert cproc.stdout.decode().replace("\r","") == stdout
+        assert cproc.stdout.decode().replace("\r", "") == stdout
 
 
 def _run_example_subprocess(name: str) -> subprocess.CompletedProcess:

--- a/tests/integration/test_readme.py
+++ b/tests/integration/test_readme.py
@@ -29,7 +29,6 @@ def _run_example_subprocess(name: str) -> subprocess.CompletedProcess:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         cwd=ROOT_PROJ_DIR,
-        shell=True,
     )
     assert cproc.returncode == 0, cproc.stderr.decode() if cproc.stderr else None
     return cproc

--- a/tests/integration/test_readme.py
+++ b/tests/integration/test_readme.py
@@ -9,16 +9,16 @@ README_PKG = Path(__file__).parent / "readme"
 class TestReadmeExamples:
     def test_usage_subprocess(self) -> None:
         cproc = _run_example_subprocess("usage")
-        assert cproc.stdout == b"[1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 4, 8, 16, 1, 3, 9, 27, 81, 1, 4, 16, 64, 256]\r\n"
+        assert cproc.stdout.decode().replace("\r","") == "[1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 4, 8, 16, 1, 3, 9, 27, 81, 1, 4, 16, 64, 256]\n"
 
     def test_dependents_and_mermaid_subprocess(self) -> None:
         cproc = _run_example_subprocess("dependents_and_mermaid")
-        stdout = b"<IPython.core.display.Markdown object>\r\n" * 11
-        stdout += b"[0, 1764, 3528, 5292, 7056, 8820, 10584, 12348, 14112, 15876]\r\n"
+        stdout = "<IPython.core.display.Markdown object>\n" * 11
+        stdout += "[0, 1764, 3528, 5292, 7056, 8820, 10584, 12348, 14112, 15876]\n"
 
         # Final mermaid display
-        stdout += b"<IPython.core.display.Markdown object>\r\n"
-        assert cproc.stdout == stdout
+        stdout += "<IPython.core.display.Markdown object>\n"
+        assert cproc.stdout.decode().replace("\r","") == stdout
 
 
 def _run_example_subprocess(name: str) -> subprocess.CompletedProcess:

--- a/tests/integration/test_readme.py
+++ b/tests/integration/test_readme.py
@@ -30,7 +30,6 @@ class TestReadmeExamples:
             '\n'
             '    DependentTask <-- SlowTask: slow_task\n'
         )
-        
 
         stdout = cproc.stdout.decode().replace("\r", "")
         assert stdout.endswith(listout + diagram)

--- a/tests/integration/test_readme.py
+++ b/tests/integration/test_readme.py
@@ -5,6 +5,7 @@ from pathlib import Path
 ROOT_PROJ_DIR = Path(__file__).parents[3]
 README_PKG = Path(__file__).parent / "readme"
 
+
 class TestReadmeExamples:
     def test_usage_subprocess(self) -> None:
         cproc = _run_example_subprocess("usage")

--- a/tests/integration/test_readme.py
+++ b/tests/integration/test_readme.py
@@ -30,5 +30,6 @@ def _run_example_subprocess(name: str) -> subprocess.CompletedProcess:
         stderr=subprocess.PIPE,
         cwd=ROOT_PROJ_DIR,
     )
-    assert cproc.returncode == 0, cproc.stderr.decode() if cproc.stderr else None
+    msg = cproc.stderr.decode() if cproc.stderr else None
+    assert (cproc.returncode == 0), msg
     return cproc

--- a/tests/integration/test_readme.py
+++ b/tests/integration/test_readme.py
@@ -13,12 +13,12 @@ class TestReadmeExamples:
 
     def test_dependents_and_mermaid_subprocess(self) -> None:
         cproc = _run_example_subprocess("dependents_and_mermaid")
-        stdout = "<IPython.core.display.Markdown object>\n" * 11
-        stdout += "[0, 1764, 3528, 5292, 7056, 8820, 10584, 12348, 14112, 15876]\n"
+        mkdown_obj = "<IPython.core.display.Markdown object>\n"
+        listout = "[0, 1764, 3528, 5292, 7056, 8820, 10584, 12348, 14112, 15876]\n"
 
-        # Final mermaid display
-        stdout += "<IPython.core.display.Markdown object>\n"
-        assert cproc.stdout.decode().replace("\r", "") == stdout
+        stdout = cproc.stdout.decode().replace("\r", "")
+        assert stdout.startswith(mkdown_obj)
+        assert stdout.endswith(listout + mkdown_obj)
 
 
 def _run_example_subprocess(name: str) -> subprocess.CompletedProcess:

--- a/tests/integration/test_readme.py
+++ b/tests/integration/test_readme.py
@@ -17,7 +17,6 @@ class TestReadmeExamples:
         listout = "[0, 1764, 3528, 5292, 7056, 8820, 10584, 12348, 14112, 15876]\n"
 
         stdout = cproc.stdout.decode().replace("\r", "")
-        assert stdout.startswith(mkdown_obj)
         assert stdout.endswith(listout + mkdown_obj)
 
 


### PR DESCRIPTION
Yucky subprocess calls required - I tried importing the module but it interferes with the multiprocessing, at least on Windows. Really needs to be called within a `__name__ == "__main__"` block.

See #14 for why the test uses `endswith` rather than an equality comparison, because there is some output which occurs on Windows but not Linux.