### PR TITLE
Fix incorrect key for repository URL declaration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     {name = "Ben Denham", email = "ben@denham.nz"},
 ]
 readme = "README.md"
-repository = "https://github.com/ben-denham/labtech"
+urls.repository = "https://github.com/ben-denham/labtech"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Developers",


### PR DESCRIPTION
For reference:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls

The current approach doesn't match the schema checks I have in my IDE. I don't think it would cause problems as such though, it's just it would be ignored as a key by PyPI, whereas this new approach would allow PyPI to have this link provided.