### PR TITLE
Enable Ruff TC rules to identify imports that can be moved behind a `…

### DIFF
--- a/labtech/monitor.py
+++ b/labtech/monitor.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from datetime import datetime
 from itertools import zip_longest
 from string import Template
-from typing import Optional, Sequence, cast
+from typing import TYPE_CHECKING, Optional, Sequence, cast
 
 import psutil
 
 from .exceptions import LabError
-from .types import Runner, TaskMonitorInfo, TaskMonitorInfoItem, TaskMonitorInfoValue
 from .utils import tqdm
+
+if TYPE_CHECKING:
+    from .types import Runner, TaskMonitorInfo, TaskMonitorInfoItem, TaskMonitorInfoValue
 
 
 def get_info_value(task_info_item: TaskMonitorInfoItem) -> TaskMonitorInfoValue:
@@ -54,7 +58,7 @@ class TerminalMultilineDisplay(MultilineDisplay):
         for pbar, line in zip_longest(self.pbars, lines, fillvalue=''):
             # Safe to cast pbar, as pbars will always be the longest
             # list and items will never be strings.
-            cast(tqdm, pbar).set_description_str(line)
+            cast('tqdm', pbar).set_description_str(line)
 
     def show(self) -> None:
         pass

--- a/labtech/tasks.py
+++ b/labtech/tasks.py
@@ -1,10 +1,10 @@
 """Utilities for defining tasks."""
+from __future__ import annotations
 
 from dataclasses import dataclass, fields
 from enum import Enum
 from inspect import isclass
-from types import UnionType
-from typing import Any, Optional, Sequence, TypeAlias, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Sequence, TypeAlias, Union, cast
 
 from frozendict import frozendict
 
@@ -14,6 +14,9 @@ from .types import Cache, LabContext, ResultMeta, ResultsMap, ResultT, Task, Tas
 from .utils import ensure_dict_key_str
 
 ParamScalar: TypeAlias = None | str | bool | float | int | Enum
+
+if TYPE_CHECKING:
+    from types import UnionType
 
 
 class CacheDefault:
@@ -40,7 +43,7 @@ def immutable_param_value(key: str, value: Any) -> Any:
             ensure_dict_key_str(dict_key, exception_type=TaskError): immutable_param_value(f'{key}["{dict_key}"]', dict_value)
             for dict_key, dict_value in value.items()
         })
-    is_scalar = isinstance(value, cast(UnionType, ParamScalar))
+    is_scalar = isinstance(value, cast('UnionType', ParamScalar))
     if is_scalar or is_task(value):
         return value
     raise TaskError(f"Unsupported type '{type(value).__qualname__}' in parameter value '{key}'.")
@@ -95,7 +98,7 @@ def _task_current_code_version(self: Task) -> Optional[str]:
 def _task_cache_key(self: Task) -> str:
     if self._cache_key is None:
         object.__setattr__(self, '_cache_key', self._lt.cache.cache_key(self))
-    return cast(str, self._cache_key)
+    return cast('str', self._cache_key)
 
 
 def _task_result(self: Task[ResultT]) -> ResultT:
@@ -255,7 +258,7 @@ def task(*args,
             cache = NullCache()
 
         cls._lt = TaskInfo(
-            cache=cast(Cache, cache),
+            cache=cast('Cache', cache),
             orig_post_init=post_init,
             max_parallel=max_parallel,
             mlflow_run=mlflow_run,
@@ -307,7 +310,7 @@ def find_tasks_in_param(param_value: Any, searched_coll_ids: Optional[set[int]] 
             for item in param_value.values()
             for task in find_tasks_in_param(item, searched_coll_ids)
         ]
-    elif isinstance(param_value, cast(UnionType, ParamScalar)):
+    elif isinstance(param_value, cast('UnionType', ParamScalar)):
         return []
 
     # This should be impossible.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ line-length = 160
 extend-exclude = ["tests/integration/readme/*.py"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I"]
+select = ["E", "F", "W", "I", "TC" ]
 
 [tool.ruff.lint.per-file-ignores]
 # Ignore non-top-level imports, repeated imports, and unordered imports in examples


### PR DESCRIPTION
…TYPE_CHECKING` block and comply with the rules.

This should make the package importable for Windows users.

See https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc for reference

The motivation here is to help protect Window's users from trying to access `ForkContext` when it's not necessary, since that's currently making the package unimportable.

The TC rules don't really work great on their own, you need to include `from __future__ import annotations` to let it see the opportunity to put annotation imports into a `TYPE_CHECKING` block