### PR TITLE
Tasks must be hashable

### DIFF
--- a/labtech/types.py
+++ b/labtech/types.py
@@ -135,6 +135,7 @@ class Task(Protocol, Generic[CovariantResultT]):
 
         """
 
+    def __hash__(self) -> int: ...
 
 TaskT = TypeVar("TaskT", bound=Task)
 


### PR DESCRIPTION
You can see this here where it is assumed that tasks can be included in sets https://github.com/nathanjmcdougall/labtech/blob/5cc3e67ae9433ccd08ab40228d6988a0b1ec31ef/labtech/lab.py#L129-L135

I found this issue using pyright in my editor. Although mypy is already being used, if you like I could also set up pyright to help identify issues like this.