### PR TITLE
Add `from __future__ import annotations` to remove quoted annotations

### DIFF
--- a/tests/labtech/test_lab.py
+++ b/tests/labtech/test_lab.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Literal
 
 import pytest
@@ -10,7 +12,7 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture()
-def lab(tmp_path: 'Path') -> Lab:
+def lab(tmp_path: Path) -> Lab:
     return Lab(storage=tmp_path, max_workers=1)
 
 

--- a/tests/labtech/test_tasks.py
+++ b/tests/labtech/test_tasks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from dataclasses import FrozenInstanceError
 from enum import Enum
@@ -48,7 +50,7 @@ class ExampleTask:
         _ExampleEnum.A,
     ],
 )
-def scalar(request: pytest.FixtureRequest) -> 'ParamScalar':
+def scalar(request: pytest.FixtureRequest) -> ParamScalar:
     return request.param
 
 
@@ -57,10 +59,10 @@ class BadCache(BaseCache):
 
     KEY_PREFIX = 'bad__'
 
-    def save_result(self, storage: 'Storage', task: 'Task[ResultT]', result: 'ResultT'):
+    def save_result(self, storage: Storage, task: Task[ResultT], result: ResultT):
         raise NotImplementedError
 
-    def load_result(self, storage: 'Storage', task: 'Task[ResultT]') -> 'ResultT':
+    def load_result(self, storage: Storage, task: Task[ResultT]) -> ResultT:
         raise NotImplementedError
 
 
@@ -307,7 +309,7 @@ class TestImmutableParamValue:
             frozendict({'a': 2}),
         )
 
-    def test_scalar(self, scalar: 'ParamScalar') -> None:
+    def test_scalar(self, scalar: ParamScalar) -> None:
         assert immutable_param_value('hello', scalar) is scalar
 
     def test_unhandled(self) -> None:
@@ -325,7 +327,7 @@ class TestImmutableParamValue:
 
 
 class TestFindTasksInParam:
-    def test_scalar(self, scalar: 'ParamScalar') -> None:
+    def test_scalar(self, scalar: ParamScalar) -> None:
         assert find_tasks_in_param(scalar) == []
 
     def test_task(self) -> None:

--- a/tests/labtech/test_utils.py
+++ b/tests/labtech/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING
 
@@ -43,7 +45,7 @@ class TestOrderedSet:
 
 
 class TestLoggerFileProxy:
-    def test_prefix_added(self, mocker: 'MockerFixture') -> None:
+    def test_prefix_added(self, mocker: MockerFixture) -> None:
         logger_func = mocker.Mock()
         mocker.patch('sys.stdout', LoggerFileProxy(logger_func, 'some_prefix:'))
         print('some_message')


### PR DESCRIPTION
This is a follow-up to this comment:
https://github.com/ben-denham/labtech/pull/38/files/6669bb50f9c5bb04547d36345b8ea25b49cdc385#r2105757028