### PR TITLE
Fix for stdout/stderr not logging or double logging from process runners

### DIFF
--- a/labtech/utils.py
+++ b/labtech/utils.py
@@ -115,6 +115,7 @@ class LoggerFileProxy:
     def flush(self):
         if self.bufs:
             self.logger_func('\n'.join([f'{self.prefix}{buf}' for buf in self.bufs]))
+            self.bufs = []
 
 
 def ensure_dict_key_str(value, *, exception_type: type[Exception]) -> str:


### PR DESCRIPTION
Resolves #47 